### PR TITLE
Bumping version to 2.29.0 and updating depercated GHA versions

### DIFF
--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -17,7 +17,7 @@ jobs:
         uses: Start9Labs/sdk@v1
 
       - name: Checkout services repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build the service package
         id: build
@@ -30,7 +30,7 @@ jobs:
         shell: bash
 
       - name: Upload .s9pk
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build.outputs.package_id }}.s9pk
           path: ./${{ steps.build.outputs.package_id }}.s9pk

--- a/.github/workflows/releaseService.yml
+++ b/.github/workflows/releaseService.yml
@@ -15,7 +15,7 @@ jobs:
         uses: Start9Labs/sdk@v1
 
       - name: Checkout services repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build the service package
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM filebrowser/filebrowser:v2.27.0
+FROM filebrowser/filebrowser:v2.29.0
 
 WORKDIR /root
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 id: filebrowser
 title: "File Browser"
-version: 2.27.0
+version: 2.29.0
 release-notes: |
   - **Language Support**: Updates have been made to support more languages, including Modern Greek, Chinese, and Hebrew.
   - **Frontend Enhancements**: Several dependencies in the frontend have been updated for better performance and security. Also, a feature has been added to display image resolutions in file details.

--- a/scripts/procedures/migration.ts
+++ b/scripts/procedures/migration.ts
@@ -3,7 +3,7 @@ import { manifest } from "../generated/manifest.ts";
 
 export const migration: T.ExpectedExports.migration = migrations.fromMapping(
   {
-    /// No migrations for 2.27.0
+    /// No migrations for 2.29.0
   },
   manifest.version,
 );


### PR DESCRIPTION
(Still in draft since I need to test this out first on my hardware)

Filebrowser has had some nice changes  that would be useful for start-os. 

For example, 2.29.0 now supports showing [upload progress as percentage and file size / total file size](https://github.com/filebrowser/filebrowser/pull/3111) and a [fix for aborted uploads](https://github.com/filebrowser/filebrowser/pull/3114) leaving behind partial files. (Disclaimer: I made these two changes) 

Currently, the start-os version is on 2.27.0.

[2.29.0 changes](https://github.com/filebrowser/filebrowser/releases/tag/v2.29.0)
[2.28.0 changes](https://github.com/filebrowser/filebrowser/releases/tag/v2.28.0)