### PR TITLE
Fixes/040

### DIFF
--- a/startos/init.ts
+++ b/startos/init.ts
@@ -20,7 +20,7 @@ const postInstall = sdk.setupPostInstall(async ({ effects }) => {
   await sdk.SubContainer.with(
     effects,
     { imageId: 'filebrowser' },
-    sdk.Mounts.of().addVolume('main', null, '/root', false),
+    sdk.Mounts.of().addVolume('main', null, mnt, false),
     'set-admin',
     async (sub) => {
       await sub.exec([

--- a/startos/init.ts
+++ b/startos/init.ts
@@ -12,7 +12,7 @@ import { mkdir } from 'fs/promises'
 // **** Pre Install ****
 const preInstall = sdk.setupPreInstall(async ({ effects }) => {
   await jsonFile.write(effects, configDefaults)
-  await mkdir('/media/startos/volumes/main/files')
+  await mkdir('/media/startos/volumes/main/files', { recursive: true })
 })
 
 // **** Post Install ****

--- a/startos/init.ts
+++ b/startos/init.ts
@@ -12,7 +12,7 @@ import { mkdir } from 'fs/promises'
 // **** Pre Install ****
 const preInstall = sdk.setupPreInstall(async ({ effects }) => {
   await jsonFile.write(effects, configDefaults)
-  await mkdir('/media/startos/volumes/main/My files')
+  await mkdir('/media/startos/volumes/main/files')
 })
 
 // **** Post Install ****

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -13,7 +13,7 @@ export const configDefaults = {
   address: '0.0.0.0',
   log: 'stdout',
   database: `${mnt}/filebrowser.db`,
-  root: `${mnt}/My files`,
+  root: `${mnt}/files`,
   tokenExpirationTime: '2h',
 }
 

--- a/startos/versions/v2.32.0.1.ts
+++ b/startos/versions/v2.32.0.1.ts
@@ -20,7 +20,7 @@ export const v_2_32_0_1 = VersionInfo.of({
       })
 
       // rename root
-      await rename('/root/data', '/root/My files')
+      await rename('/root/data', '/root/files')
 
       // remove old start9 dir
       await rmdir('/root/start9')

--- a/startos/versions/v2.32.0.1.ts
+++ b/startos/versions/v2.32.0.1.ts
@@ -2,7 +2,7 @@ import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 import { readFile, rename, rmdir } from 'fs/promises'
 import { load } from 'js-yaml'
 import { jsonFile } from '../file-models/filebrowser.json'
-import { configDefaults } from '../utils'
+import { configDefaults, mnt } from '../utils'
 
 export const v_2_32_0_1 = VersionInfo.of({
   version: '2.32.0:1',
@@ -20,7 +20,7 @@ export const v_2_32_0_1 = VersionInfo.of({
       })
 
       // rename root
-      await rename('/root/data', '/root/files')
+      await rename('/root/data', `${mnt}/files`)
 
       // remove old start9 dir
       await rmdir('/root/start9')


### PR DESCRIPTION
- Install is failing, traces to subcontainer setup in `setupPostInstall`
```
Migration Failed: Error: Failed to start subcontainer filebrowser